### PR TITLE
docs: add missing 6.3.0 EE changelog entries

### DIFF
--- a/en_US/changes/changes-ee-v6.md
+++ b/en_US/changes/changes-ee-v6.md
@@ -303,6 +303,12 @@ Make sure to check the breaking changes and known issues before upgrading to EMQ
 
 - [#18449](https://github.com/emqx/emqx/pull/18449) Fixed a rare race condition in which the PostgreSQL Action encountered a `sock_closed` error while writing data and incorrectly treated it as unrecoverable. EMQX treats the error as recoverable.
 
+- [#18767](https://github.com/emqx/emqx/pull/18767) Fixed the RocketMQ connector being reported as belonging to a namespace it does not belong to.
+
+  The RocketMQ connector has its own `namespace` configuration field, holding the RocketMQ instance namespace. Connector API responses returned that value under the same JSON key used for the EMQX namespace, so the Dashboard treated the connector as owned by a namespace of that name. It showed "Only the administrator of namespace <name> can perform operations on the connector", and opening the connector failed with "Managed namespace not found".
+
+  The `namespace` field in connector API responses now always holds the EMQX namespace. The RocketMQ instance namespace is no longer returned, and it is kept unchanged when a connector is updated without it.
+
 #### Rule Engine
 
 - [#18527](https://github.com/emqx/emqx/pull/18527) Fixed repeated `badarg` errors in the log when a message was published while the schema validation, message transformation, or rule engine topic index table was unavailable. Such a publish now proceeds as if no validation, transformation, or rule matched the topic, and the broker logs a throttled `topic_index_table_missing` message instead of one error per publish. The index tables now also survive a restart of their owner process, and the hooks are removed before the tables during application shutdown, which removes the known windows where a publish could find a table missing.

--- a/en_US/changes/changes-ee-v6.md
+++ b/en_US/changes/changes-ee-v6.md
@@ -303,11 +303,11 @@ Make sure to check the breaking changes and known issues before upgrading to EMQ
 
 - [#18449](https://github.com/emqx/emqx/pull/18449) Fixed a rare race condition in which the PostgreSQL Action encountered a `sock_closed` error while writing data and incorrectly treated it as unrecoverable. EMQX treats the error as recoverable.
 
-- [#18767](https://github.com/emqx/emqx/pull/18767) Fixed the RocketMQ connector being reported as belonging to a namespace it does not belong to.
+- [#18767](https://github.com/emqx/emqx/pull/18767) Fixed an issue where EMQX incorrectly treated the RocketMQ instance namespace as the connector's EMQX namespace.
 
-  The RocketMQ connector has its own `namespace` configuration field, holding the RocketMQ instance namespace. Connector API responses returned that value under the same JSON key used for the EMQX namespace, so the Dashboard treated the connector as owned by a namespace of that name. It showed "Only the administrator of namespace <name> can perform operations on the connector", and opening the connector failed with "Managed namespace not found".
+  A RocketMQ connector has a `namespace` configuration field that stores the RocketMQ instance namespace. Connector API responses previously returned this value under the same JSON key as the EMQX namespace. As a result, the Dashboard treated the connector as belonging to an EMQX namespace with the same name. The Dashboard displayed "Only the administrator of namespace <name> can perform operations on the connector", and opening the connector failed with "Managed namespace not found".
 
-  The `namespace` field in connector API responses now always holds the EMQX namespace. The RocketMQ instance namespace is no longer returned, and it is kept unchanged when a connector is updated without it.
+  The `namespace` field in connector API responses always represents the EMQX namespace. Connector API responses no longer include the RocketMQ instance namespace. If an update request omits the RocketMQ `namespace` configuration field, EMQX preserves its existing value.
 
 #### Rule Engine
 

--- a/en_US/changes/changes-ee-v6.md
+++ b/en_US/changes/changes-ee-v6.md
@@ -341,6 +341,12 @@ Make sure to check the breaking changes and known issues before upgrading to EMQ
 
   The gateway now also accepts CRLF (`\r\n`) line endings in frames and CRLF heartbeats. Before this fix, clients using CRLF line endings could not connect.
 
+- [#18700](https://github.com/emqx/emqx/pull/18700) Fixed an issue where saving an existing NATS Gateway configuration from the Dashboard could replace its authentication credentials with the masked value displayed in the form, causing NATS clients to fail authentication.
+
+  Authentication credentials are now preserved when users update other Gateway settings without changing the authentication configuration.
+
+  NATS Gateway authentication settings now reject duplicate authentication methods and credential entries, including duplicate NKeys and JWT account entries, to prevent ambiguous authentication behavior.
+
 #### Plugins
 
 - [#18188](https://github.com/emqx/emqx/pull/18188) Hardened the plugin framework package and runtime integrity checks.

--- a/zh_CN/changes/changes-ee-v6.md
+++ b/zh_CN/changes/changes-ee-v6.md
@@ -306,6 +306,11 @@
 - [#18436](https://github.com/emqx/emqx/pull/18436) 修复 NATS 网关内部 JWT 认证未强制检查账户 JWT `exp`/`nbf` 声明和账户级用户撤销的问题。认证期间会拒绝已过期或尚未生效的账户 JWT，以及被账户撤销的用户 JWT；现有连接会在用户 JWT 或账户 JWT 中较早的过期时间到达时断开。格式错误且由 Resolver 预加载的账户 JWT 会在网关配置验证期间被拒绝。
 - [#18494](https://github.com/emqx/emqx/pull/18494) 修复 CoAP 网关客户端报告内部 Keepalive 检查间隔而不是已配置心跳间隔的问题。网关 API 和 `emqx ctl gateway-clients list coap` 现在会以秒为单位报告配置的心跳值。
 - [#18504](https://github.com/emqx/emqx/pull/18504) 修复 STOMP 帧对转义请求头字符和 CRLF 行尾的解析。网关现在会按照 STOMP 1.2 的要求，在请求头名称和值中解码 `\c`、`\r`、`\n` 和 `\\`。CONNECT 和 CONNECTED 帧除外：为兼容 STOMP 1.0，这两种帧的请求头（包括含冒号或反斜杠的密码）会原样传递。其他帧中未定义的转义序列会作为帧错误被拒绝。网关现在也支持 CRLF（`\r\n`）行尾和 CRLF 心跳；此前使用 CRLF 行尾的客户端无法连接。
+- [#18700](https://github.com/emqx/emqx/pull/18700) 修复从 Dashboard 保存已有 NATS 网关配置时，认证凭据可能被表单中显示的掩码值替换，导致 NATS 客户端认证失败的问题。
+
+  当用户更新其他网关设置而不更改认证配置时，现在会保留认证凭据。
+
+  NATS 网关认证配置现在会拒绝重复的认证方式和凭据条目，包括重复的 NKey 和 JWT 账户条目，以避免认证行为不明确。
 
 #### 插件
 

--- a/zh_CN/changes/changes-ee-v6.md
+++ b/zh_CN/changes/changes-ee-v6.md
@@ -284,6 +284,11 @@
 - [#18300](https://github.com/emqx/emqx/pull/18300) 无论 `verify` 模式为何，连接器 TLS 设置中的空证书文件字段现在都视为未配置。此前，`verify_peer` 模式会拒绝空的客户端证书字段，尽管对端验证并不要求客户端证书。
 - [#18392](https://github.com/emqx/emqx/pull/18392) 修复不同命名空间中同名的聚合动作（S3、S3Tables、Azure Blob Storage、Snowflake Aggregated）共用临时文件工作目录的问题。
 - [#18449](https://github.com/emqx/emqx/pull/18449) 修复 PostgreSQL 动作写入数据时将罕见的 `sock_closed` 竞态错误错误地视为不可恢复的问题。EMQX 现在将其视为可恢复。
+- [#18767](https://github.com/emqx/emqx/pull/18767) 修复 RocketMQ 连接器被报告为属于其实际并不归属的命名空间的问题。
+
+  RocketMQ 连接器自身带有一个 `namespace` 配置字段，用于保存 RocketMQ 实例命名空间。连接器 API 响应此前会将该值放在与 EMQX 命名空间相同的 JSON 字段中，导致 Dashboard 将该连接器视为属于这个名称的命名空间，并显示“Only the administrator of namespace <name> can perform operations on the connector”；打开连接器时还会失败并提示“Managed namespace not found”。
+
+  现在，连接器 API 响应中的 `namespace` 字段始终表示 EMQX 命名空间。RocketMQ 实例命名空间不再返回，并且在更新连接器时如果未提供该字段，其值会保持不变。
 
 #### 规则引擎
 

--- a/zh_CN/changes/changes-ee-v6.md
+++ b/zh_CN/changes/changes-ee-v6.md
@@ -284,11 +284,11 @@
 - [#18300](https://github.com/emqx/emqx/pull/18300) 无论 `verify` 模式为何，连接器 TLS 设置中的空证书文件字段现在都视为未配置。此前，`verify_peer` 模式会拒绝空的客户端证书字段，尽管对端验证并不要求客户端证书。
 - [#18392](https://github.com/emqx/emqx/pull/18392) 修复不同命名空间中同名的聚合动作（S3、S3Tables、Azure Blob Storage、Snowflake Aggregated）共用临时文件工作目录的问题。
 - [#18449](https://github.com/emqx/emqx/pull/18449) 修复 PostgreSQL 动作写入数据时将罕见的 `sock_closed` 竞态错误错误地视为不可恢复的问题。EMQX 现在将其视为可恢复。
-- [#18767](https://github.com/emqx/emqx/pull/18767) 修复 RocketMQ 连接器被报告为属于其实际并不归属的命名空间的问题。
+- [#18767](https://github.com/emqx/emqx/pull/18767) 修复 EMQX 将 RocketMQ 实例命名空间误识别为连接器所属 EMQX 命名空间的问题。
 
-  RocketMQ 连接器自身带有一个 `namespace` 配置字段，用于保存 RocketMQ 实例命名空间。连接器 API 响应此前会将该值放在与 EMQX 命名空间相同的 JSON 字段中，导致 Dashboard 将该连接器视为属于这个名称的命名空间，并显示“Only the administrator of namespace <name> can perform operations on the connector”；打开连接器时还会失败并提示“Managed namespace not found”。
+  RocketMQ 连接器的 `namespace` 配置字段用于保存 RocketMQ 实例命名空间。此前，连接器 API 响应会将该值放在与 EMQX 命名空间相同的 JSON 字段中。因此，Dashboard 将连接器视为属于同名的 EMQX 命名空间，并显示“Only the administrator of namespace <name> can perform operations on the connector”；打开连接器也会失败并提示“Managed namespace not found”。
 
-  现在，连接器 API 响应中的 `namespace` 字段始终表示 EMQX 命名空间。RocketMQ 实例命名空间不再返回，并且在更新连接器时如果未提供该字段，其值会保持不变。
+  连接器 API 响应中的 `namespace` 字段始终表示 EMQX 命名空间，不再包含 RocketMQ 实例命名空间。更新连接器时，如果请求未提供 RocketMQ 的 `namespace` 配置字段，EMQX 会保留该字段的现有值。
 
 #### 规则引擎
 


### PR DESCRIPTION
## Summary
- add the #18767 RocketMQ namespace fix to the 6.3.0 EE changelog in English and zh_CN
- add the #18700 NATS Gateway credential preservation fix to the 6.3.0 EE changelog in English and zh_CN
- leave ja_JP unchanged

## Testing
- git diff --check