### PR TITLE
docs(changes): drop Windows references from the v6 changelog

### DIFF
--- a/en_US/changes/changes-ee-v6.md
+++ b/en_US/changes/changes-ee-v6.md
@@ -20,7 +20,7 @@ Make sure to check the breaking changes and known issues before upgrading to EMQ
 
 - [#17603](https://github.com/emqx/emqx/pull/17603) Added support for extracting subject alternative names from directly connected TLS client certificates into MQTT client attributes with `cert_san.dns`, `cert_san.ip`, `cert_san.email`, and `cert_san.uri` in `mqtt.client_attrs_init`.
 
-- [#17854](https://github.com/emqx/emqx/pull/17854) Changed the default `tcp_backend` for MQTT TCP listeners to `socket` on Unix systems to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`, and remains the default on Windows.
+- [#17854](https://github.com/emqx/emqx/pull/17854) Changed the default `tcp_backend` for MQTT TCP listeners to `socket` to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`.
 
 - [#17870](https://github.com/emqx/emqx/pull/17870) Improved in-memory session delivery behavior for slow or congested subscribers.
 

--- a/ja_JP/changes/changes-ee-v6.md
+++ b/ja_JP/changes/changes-ee-v6.md
@@ -20,7 +20,7 @@ Make sure to check the breaking changes and known issues before upgrading to EMQ
 
 - [#17603](https://github.com/emqx/emqx/pull/17603) Added support for extracting subject alternative names from directly connected TLS client certificates into MQTT client attributes with `cert_san.dns`, `cert_san.ip`, `cert_san.email`, and `cert_san.uri` in `mqtt.client_attrs_init`.
 
-- [#17854](https://github.com/emqx/emqx/pull/17854) Changed the default `tcp_backend` for MQTT TCP listeners to `socket` on Unix systems to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`, and remains the default on Windows.
+- [#17854](https://github.com/emqx/emqx/pull/17854) Changed the default `tcp_backend` for MQTT TCP listeners to `socket` to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`.
 
 - [#17870](https://github.com/emqx/emqx/pull/17870) Improved in-memory session delivery behavior for slow or congested subscribers.
 

--- a/zh_CN/changes/changes-ee-v6.md
+++ b/zh_CN/changes/changes-ee-v6.md
@@ -20,7 +20,7 @@
 
 - [#17603](https://github.com/emqx/emqx/pull/17603) 支持通过 `mqtt.client_attrs_init` 中的 `cert_san.dns`、`cert_san.ip`、`cert_san.email` 和 `cert_san.uri`，从直接连接的 TLS 客户端证书中提取主题备用名称并写入 MQTT 客户端属性。
 
-- [#17854](https://github.com/emqx/emqx/pull/17854) 为改善消息延迟和资源使用，Unix 系统上的 MQTT TCP 监听器现在默认使用 `socket` 作为 `tcp_backend`。仍可通过设置 `tcp_backend = gen_tcp` 使用 `gen_tcp` 后端；Windows 上仍默认使用 `gen_tcp`。
+- [#17854](https://github.com/emqx/emqx/pull/17854) 为改善消息延迟和资源使用，MQTT TCP 监听器现在默认使用 `socket` 作为 `tcp_backend`。仍可通过设置 `tcp_backend = gen_tcp` 使用 `gen_tcp` 后端。
 
 - [#17870](https://github.com/emqx/emqx/pull/17870) 改进内存会话向处理缓慢或发生拥塞的订阅者投递消息的行为。
 


### PR DESCRIPTION
EMQX stopped releasing Windows packages in 5.4 (documented in `breaking-changes-ce-5.4.md`: *"Stopped releasing packages for Windows"*), so a v6 changelog entry that talks about Windows behavior describes a platform we do not ship.

## The one real slip

`changes-ee-v6.md`, the [#17854](https://github.com/emqx/emqx/pull/17854) entry, in all three locales:

> Changed the default `tcp_backend` for MQTT TCP listeners to `socket` **on Unix systems** … The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`, **and remains the default on Windows**.

I dropped the `on Unix systems` qualifier along with the Windows clause. `emqx_schema.erl` really does branch on `os:type()` (`{unix,_} -> socket`, `{win32,_} -> gen_tcp`), but the `win32` branch is unreachable in any shipped build — every supported platform is Unix, so `socket` is simply the default, and the contrast only invites the question the entry should not raise. Happy to keep `on Unix systems` if you prefer it.

## Upstream will reintroduce it

The text is a verbatim copy of `changes/ee/feat-17854.en.md` in emqx.git, which still says Windows on `dev-63`. If the docs changelog is ever regenerated from upstream, this comes back — worth a follow-up PR there.

## Everything else checked and deliberately left alone

Swept all locales on release-6.0 → release-6.3, case-insensitive, all file types. The remaining hits are legitimate:

- `install-docker.md` — "Docker for Mac or Docker for Windows" as a **container host**.
- `getting-started.md` — the **MQTTX desktop client** runs on Windows.
- `emqx-ai/rtc-services/volcengine-rtc/*` — third-party **client SDK** platform list.
- `migrate-from-azure-iot-hub.md` — importing a CA cert on a **user machine** via PowerShell.
- `data-bridge-sqlserver.md` — **Microsoft** SQL Server.
- `zh_CN/faq/deployment.md` — explicitly states EMQX does **not** support Windows and recommends Docker; clarifying, not confusing.
- v3/v4/v5 changelogs and `breaking-changes-ce-5.4.md` — historical record from when Windows packages existed, including the entry announcing their removal.
- Lowercase `windows` — terminal windows, detection windows, inflight windows.

Only release-6.3 carries the #17854 entry (6.0–6.2 have no Windows references in their v6 changelogs), so no ports are needed.

`gen.py` + `directory_check.py` pass.