### PR TITLE
feat(plugin): Add sync request plugin

### DIFF
--- a/dir.yaml
+++ b/dir.yaml
@@ -345,6 +345,7 @@
     path: guides/extensions/plugin-catalog
     collapsed: true
     children:
+    - guides/extensions/plugin-catalog/6.0/emqx-sync-request
     - guides/extensions/plugin-catalog/6.0/emqx-backup-sync
     - guides/extensions/plugin-catalog/6.0/emqx-relup
     - guides/extensions/plugin-catalog/6.0/emqx-username-quota

--- a/en_US/guides/extensions/plugin-catalog.md
+++ b/en_US/guides/extensions/plugin-catalog.md
@@ -8,6 +8,12 @@ Some plugins remain specialized, while others may later be promoted into standar
 
 The plugins listed on this page are maintained as part of the [`emqx.git` monorepo](https://github.com/emqx/emqx/tree/master/plugins).
 
+## Message Delivery
+
+[Sync Request](./plugin-catalog/6.0/emqx-sync-request.md)
+
+This plugin lets an HTTP caller publish an MQTT request through the EMQX REST API and synchronously wait for the first matching MQTT response.
+
 ## Operations
 
 [Hot Upgrade (Relup)](./plugin-catalog/6.0/emqx-relup.md)

--- a/en_US/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
+++ b/en_US/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
@@ -1,0 +1,195 @@
+# Sync Request
+
+The `emqx_sync_request` plugin lets an HTTP service send an MQTT request through the EMQX REST API and receive the first matching MQTT response in the same HTTP request. The plugin is available in EMQX Enterprise 6.0.4 and later 6.0 releases.
+
+Use this plugin when a backend service needs to send a command or query to a connected MQTT client. Unlike the standard publish API, this plugin waits for and correlates the client response, handles timeouts, and manages concurrent requests. The HTTP service does not need to run an MQTT client or track request and response pairs.
+
+Before using the API, install and start `emqx_sync_request` as described in [Manage Plugins](../../plugin-management.md). The endpoint is available only while the plugin is running.
+
+## How It Works
+
+The request and response flow works as follows:
+
+1. The HTTP caller sends the MQTT request topic, response topic, `request_id`, and payload to the API.
+2. The plugin finds the MQTT client subscribed to the request topic and delivers the request directly to that client.
+3. The MQTT client processes the request and publishes a response to the response topic. For MQTT 5, the plugin includes `request_id` as Correlation Data in the request message.
+4. If the MQTT 5 client returns this Correlation Data, the plugin matches the response by response topic and Correlation Data. If the response does not include Correlation Data, the plugin matches it to the oldest pending request for the response topic. This fallback applies to MQTT 3 responses and MQTT 5 responses that omit Correlation Data. When concurrent requests use the same response topic, MQTT 5 clients should return the Correlation Data to ensure that each response is matched to the intended request.
+5. The plugin returns the first matching MQTT response to the HTTP caller. If no matching response arrives before the timeout, the API returns `504 TIMEOUT`.
+
+Request topics must match one online, non-shared subscriber exactly:
+
+- Wildcard topic filters are not matched as request receivers.
+- Shared subscriptions are not accepted as request receivers.
+- If no exact subscriber is online, the API returns `404 NO_SUBSCRIBERS`.
+- If the request topic has a shared subscription or more than one exact subscriber, the API returns `409 CONFLICT`.
+
+## Request Delivery and Response Handling
+
+The plugin stores inflight requests only in the local node's memory. It does not persist requests, subscribe to response topics, or modify MQTT payloads.
+
+EMQX delivers each request directly to the selected client instead of sending it through the normal MQTT publish pipeline. Therefore, the request is not processed by the rule engine, schema validation, message transformation, retained message handling, or delayed publishing, and it does not use the generic `/publish` API.
+
+Forwarding a request to another node and waiting for the MQTT response share the same HTTP timeout. The forwarding time reduces the time available to wait for the response.
+
+The response must be published by a client connected to the node that delivered the request, typically through the same connection that received it. A response published through another node is not matched.
+
+## Plugin Configuration
+
+These settings control the plugin-wide timeouts and resource limits on each node. Request-specific parameters are described in [Request Body](#request-body).
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `default_timeout` | `10s` | Default HTTP wait timeout when the request body omits `timeout`. |
+| `max_timeout` | `60s` | Maximum allowed per-request `timeout`. |
+| `max_inflight_requests` | `10000` | Maximum number of local HTTP requests waiting for responses on one node. |
+| `max_payload_size` | `64KB` | Maximum MQTT request payload size and maximum MQTT response payload size. |
+
+Example configuration:
+
+```hocon
+default_timeout = "10s"
+max_timeout = "60s"
+max_inflight_requests = 10000
+max_payload_size = "64KB"
+```
+
+Update plugin configuration through the standard plugin configuration API:
+
+```http
+PUT /api/v5/plugins/<name-vsn>/config
+```
+
+## Synchronous Request API
+
+Call the following endpoint to send an MQTT request and wait for its response:
+
+```http
+POST /api/v5/plugin_api/emqx_sync_request/request
+```
+
+Use the same authentication methods as other EMQX management APIs. Bearer tokens obtained from Dashboard login are accepted. API keys must be sent with HTTP Basic authentication and require the `publish` scope.
+
+### Request Body
+
+```json
+{
+  "timeout": "5s",
+  "request": {
+    "topic": "devices/1001/request",
+    "response_topic": "devices/1001/response",
+    "request_id": "request-id-1",
+    "qos": 0,
+    "payload_encoding": "plain",
+    "payload": "{\"cmd\":\"reboot\"}",
+    "content_type": "application/json"
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `timeout` | duration string | No | `default_timeout` | Maximum time to wait for a matching MQTT response. It must be greater than `0` and no greater than `max_timeout`. Examples: `100ms`, `5s`, `1m`. |
+| `request` | object | Yes | - | MQTT request parameters. |
+
+The `request` object contains the following fields:
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `topic` | string | Yes | - | MQTT request topic. It must be a topic name, not a topic filter, so `+` and `#` are not allowed. Exactly one non-shared subscriber must be online for this topic. |
+| `response_topic` | string | Yes | - | MQTT response topic. It must also be a topic name without `+` or `#`. |
+| `request_id` | string | Yes | - | Plain string used as MQTT 5 Correlation Data and echoed in the HTTP response. The maximum length is 128 bytes. |
+| `qos` | integer | No | `0` | MQTT QoS for the request. Allowed values are `0`, `1`, and `2`. |
+| `payload_encoding` | string | No | `plain` | Request payload encoding. Allowed values are `plain` and `base64`. |
+| `payload` | string | Yes | - | Request payload. With `plain`, the string bytes are used as the MQTT payload. With `base64`, the value must be valid base64 and the decoded bytes are used as the MQTT payload. The MQTT payload must not exceed `max_payload_size`. |
+| `content_type` | string | No | - | MQTT 5 Content Type for the request. MQTT 3 clients do not receive this property. |
+
+### Success Response
+
+A successful request returns HTTP `200`. The MQTT response payload is always returned as base64.
+
+```json
+{
+  "code": "OK",
+  "message": "OK",
+  "response": {
+    "topic": "devices/1001/response",
+    "request_id": "request-id-1",
+    "payload_encoding": "base64",
+    "payload": "eyJyZXN1bHQiOiJvayJ9",
+    "content_type": "application/json"
+  }
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `code` | Always `OK`. |
+| `message` | Always `OK`. |
+| `response.topic` | MQTT response topic. |
+| `response.request_id` | The `request_id` from the HTTP request. |
+| `response.payload_encoding` | Always `base64`. |
+| `response.payload` | Base64-encoded MQTT response payload. |
+| `response.content_type` | Optional. MQTT 5 Content Type from the response PUBLISH. This field is omitted when the responder does not send it, including MQTT 3 responders. |
+
+### Error Responses
+
+Errors use the same `code` and `message` response shape as other EMQX management APIs.
+
+| HTTP Status | Code | Meaning |
+| --- | --- | --- |
+| `400` | `BAD_REQUEST` | Invalid JSON body, invalid field value, request payload too large, or MQTT response payload too large. |
+| `401` | `BAD_API_KEY_OR_SECRET` | API key authentication failed. Returned by EMQX management API authentication. |
+| `403` | `UNAUTHORIZED_ROLE` | The API key does not have permission to call this API. Returned by EMQX management API authorization. |
+| `404` | `NO_SUBSCRIBERS` | No exact, non-shared subscriber is online for the request topic. Wildcard subscribers are ignored. |
+| `409` | `CONFLICT` | The request topic has a shared subscription or more than one exact subscriber. |
+| `429` | `TOO_MANY_REQUESTS` | The local node already has `max_inflight_requests` HTTP requests waiting for responses. |
+| `503` | `SERVICE_UNAVAILABLE` | Failed to dispatch the request to the subscriber node. |
+| `504` | `TIMEOUT` | Timed out waiting for a matching MQTT response. |
+| `500` | `INTERNAL_ERROR` | Unexpected server-side error. |
+
+## Operational Diagnostics
+
+The plugin provides a node-local diagnostic CLI command:
+
+```bash
+emqx ctl sync_request status
+```
+
+Example output:
+
+```text
+Counters since plugin start:
+sync_request.requests.total: 42
+sync_request.requests.succeeded: 39
+sync_request.requests.failed: 3
+sync_request.requests.bad_request: 1
+sync_request.requests.no_subscribers: 1
+sync_request.requests.conflict: 0
+sync_request.requests.too_many_requests: 0
+sync_request.requests.dispatch_failed: 0
+sync_request.requests.timeout: 1
+sync_request.requests.internal_error: 0
+
+Current gauges:
+sync_request.inflight_requests: 0
+sync_request.pending_responses: 0
+```
+
+These values are not cluster-wide aggregates. The command reads only the node where it runs. In a cluster, run it on each node that may receive the HTTP request or deliver the MQTT response.
+
+Only requests that reach the plugin handler are counted. Management API authentication and authorization failures are handled by EMQX before the plugin runs.
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `sync_request.requests.total` | counter | HTTP sync request attempts handled. |
+| `sync_request.requests.succeeded` | counter | Requests that returned HTTP `200`. |
+| `sync_request.requests.failed` | counter | Requests that returned a non-`200` HTTP status. |
+| `sync_request.requests.bad_request` | counter | Requests rejected with `400 BAD_REQUEST`. |
+| `sync_request.requests.no_subscribers` | counter | Requests rejected because no exact, non-shared subscriber was online. |
+| `sync_request.requests.conflict` | counter | Requests rejected because the request topic matched multiple or shared subscribers. |
+| `sync_request.requests.too_many_requests` | counter | Requests rejected because `max_inflight_requests` was reached. |
+| `sync_request.requests.dispatch_failed` | counter | Requests that could not be dispatched to the subscriber node. |
+| `sync_request.requests.timeout` | counter | Requests that timed out waiting for a matching MQTT response. |
+| `sync_request.requests.internal_error` | counter | Requests that failed with an unexpected internal error. |
+| `sync_request.inflight_requests` | gauge | HTTP requests currently waiting for MQTT responses. |
+| `sync_request.pending_responses` | gauge | Pending response registrations created after request delivery. |

--- a/en_US/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
+++ b/en_US/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
@@ -10,7 +10,7 @@ Before using the API, install and start `emqx_sync_request` as described in [Man
 
 The request and response flow works as follows:
 
-1. The HTTP caller sends the MQTT request topic, response topic, `request_id`, and payload to the API.
+1. The HTTP caller sends an HTTP request to the API that includes the MQTT request topic, response topic, `request_id`, and payload.
 2. The plugin finds the MQTT client subscribed to the request topic and delivers the request directly to that client.
 3. The MQTT client processes the request and publishes a response to the response topic. For MQTT 5, the plugin includes `request_id` as Correlation Data in the request message.
 4. If the MQTT 5 client returns this Correlation Data, the plugin matches the response by response topic and Correlation Data. If the response does not include Correlation Data, the plugin matches it to the oldest pending request for the response topic. This fallback applies to MQTT 3 responses and MQTT 5 responses that omit Correlation Data. When concurrent requests use the same response topic, MQTT 5 clients should return the Correlation Data to ensure that each response is matched to the intended request.

--- a/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
+++ b/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
@@ -1,0 +1,195 @@
+# Sync Request
+
+The `emqx_sync_request` plugin lets an HTTP service send an MQTT request through the EMQX REST API and receive the first matching MQTT response in the same HTTP request. The plugin is available in EMQX Enterprise 6.0.4 and later 6.0 releases.
+
+Use this plugin when a backend service needs to send a command or query to a connected MQTT client. Unlike the standard publish API, this plugin waits for and correlates the client response, handles timeouts, and manages concurrent requests. The HTTP service does not need to run an MQTT client or track request and response pairs.
+
+Before using the API, install and start `emqx_sync_request` as described in [Manage Plugins](../../plugin-management.md). The endpoint is available only while the plugin is running.
+
+## How It Works
+
+The request and response flow works as follows:
+
+1. The HTTP caller sends the MQTT request topic, response topic, `request_id`, and payload to the API.
+2. The plugin finds the MQTT client subscribed to the request topic and delivers the request directly to that client.
+3. The MQTT client processes the request and publishes a response to the response topic. For MQTT 5, the plugin includes `request_id` as Correlation Data in the request message.
+4. If the MQTT 5 client returns this Correlation Data, the plugin matches the response by response topic and Correlation Data. If the response does not include Correlation Data, the plugin matches it to the oldest pending request for the response topic. This fallback applies to MQTT 3 responses and MQTT 5 responses that omit Correlation Data. When concurrent requests use the same response topic, MQTT 5 clients should return the Correlation Data to ensure that each response is matched to the intended request.
+5. The plugin returns the first matching MQTT response to the HTTP caller. If no matching response arrives before the timeout, the API returns `504 TIMEOUT`.
+
+Request topics must match one online, non-shared subscriber exactly:
+
+- Wildcard topic filters are not matched as request receivers.
+- Shared subscriptions are not accepted as request receivers.
+- If no exact subscriber is online, the API returns `404 NO_SUBSCRIBERS`.
+- If the request topic has a shared subscription or more than one exact subscriber, the API returns `409 CONFLICT`.
+
+## Request Delivery and Response Handling
+
+The plugin stores inflight requests only in the local node's memory. It does not persist requests, subscribe to response topics, or modify MQTT payloads.
+
+EMQX delivers each request directly to the selected client instead of sending it through the normal MQTT publish pipeline. Therefore, the request is not processed by the rule engine, schema validation, message transformation, retained message handling, or delayed publishing, and it does not use the generic `/publish` API.
+
+Forwarding a request to another node and waiting for the MQTT response share the same HTTP timeout. The forwarding time reduces the time available to wait for the response.
+
+The response must be published by a client connected to the node that delivered the request, typically through the same connection that received it. A response published through another node is not matched.
+
+## Plugin Configuration
+
+These settings control the plugin-wide timeouts and resource limits on each node. Request-specific parameters are described in [Request Body](#request-body).
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `default_timeout` | `10s` | Default HTTP wait timeout when the request body omits `timeout`. |
+| `max_timeout` | `60s` | Maximum allowed per-request `timeout`. |
+| `max_inflight_requests` | `10000` | Maximum number of local HTTP requests waiting for responses on one node. |
+| `max_payload_size` | `64KB` | Maximum MQTT request payload size and maximum MQTT response payload size. |
+
+Example configuration:
+
+```hocon
+default_timeout = "10s"
+max_timeout = "60s"
+max_inflight_requests = 10000
+max_payload_size = "64KB"
+```
+
+Update plugin configuration through the standard plugin configuration API:
+
+```http
+PUT /api/v5/plugins/<name-vsn>/config
+```
+
+## Synchronous Request API
+
+Call the following endpoint to send an MQTT request and wait for its response:
+
+```http
+POST /api/v5/plugin_api/emqx_sync_request/request
+```
+
+Use the same authentication methods as other EMQX management APIs. Bearer tokens obtained from Dashboard login are accepted. API keys must be sent with HTTP Basic authentication and require the `publish` scope.
+
+### Request Body
+
+```json
+{
+  "timeout": "5s",
+  "request": {
+    "topic": "devices/1001/request",
+    "response_topic": "devices/1001/response",
+    "request_id": "request-id-1",
+    "qos": 0,
+    "payload_encoding": "plain",
+    "payload": "{\"cmd\":\"reboot\"}",
+    "content_type": "application/json"
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `timeout` | duration string | No | `default_timeout` | Maximum time to wait for a matching MQTT response. It must be greater than `0` and no greater than `max_timeout`. Examples: `100ms`, `5s`, `1m`. |
+| `request` | object | Yes | - | MQTT request parameters. |
+
+The `request` object contains the following fields:
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `topic` | string | Yes | - | MQTT request topic. It must be a topic name, not a topic filter, so `+` and `#` are not allowed. Exactly one non-shared subscriber must be online for this topic. |
+| `response_topic` | string | Yes | - | MQTT response topic. It must also be a topic name without `+` or `#`. |
+| `request_id` | string | Yes | - | Plain string used as MQTT 5 Correlation Data and echoed in the HTTP response. The maximum length is 128 bytes. |
+| `qos` | integer | No | `0` | MQTT QoS for the request. Allowed values are `0`, `1`, and `2`. |
+| `payload_encoding` | string | No | `plain` | Request payload encoding. Allowed values are `plain` and `base64`. |
+| `payload` | string | Yes | - | Request payload. With `plain`, the string bytes are used as the MQTT payload. With `base64`, the value must be valid base64 and the decoded bytes are used as the MQTT payload. The MQTT payload must not exceed `max_payload_size`. |
+| `content_type` | string | No | - | MQTT 5 Content Type for the request. MQTT 3 clients do not receive this property. |
+
+### Success Response
+
+A successful request returns HTTP `200`. The MQTT response payload is always returned as base64.
+
+```json
+{
+  "code": "OK",
+  "message": "OK",
+  "response": {
+    "topic": "devices/1001/response",
+    "request_id": "request-id-1",
+    "payload_encoding": "base64",
+    "payload": "eyJyZXN1bHQiOiJvayJ9",
+    "content_type": "application/json"
+  }
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `code` | Always `OK`. |
+| `message` | Always `OK`. |
+| `response.topic` | MQTT response topic. |
+| `response.request_id` | The `request_id` from the HTTP request. |
+| `response.payload_encoding` | Always `base64`. |
+| `response.payload` | Base64-encoded MQTT response payload. |
+| `response.content_type` | Optional. MQTT 5 Content Type from the response PUBLISH. This field is omitted when the responder does not send it, including MQTT 3 responders. |
+
+### Error Responses
+
+Errors use the same `code` and `message` response shape as other EMQX management APIs.
+
+| HTTP Status | Code | Meaning |
+| --- | --- | --- |
+| `400` | `BAD_REQUEST` | Invalid JSON body, invalid field value, request payload too large, or MQTT response payload too large. |
+| `401` | `BAD_API_KEY_OR_SECRET` | API key authentication failed. Returned by EMQX management API authentication. |
+| `403` | `UNAUTHORIZED_ROLE` | The API key does not have permission to call this API. Returned by EMQX management API authorization. |
+| `404` | `NO_SUBSCRIBERS` | No exact, non-shared subscriber is online for the request topic. Wildcard subscribers are ignored. |
+| `409` | `CONFLICT` | The request topic has a shared subscription or more than one exact subscriber. |
+| `429` | `TOO_MANY_REQUESTS` | The local node already has `max_inflight_requests` HTTP requests waiting for responses. |
+| `503` | `SERVICE_UNAVAILABLE` | Failed to dispatch the request to the subscriber node. |
+| `504` | `TIMEOUT` | Timed out waiting for a matching MQTT response. |
+| `500` | `INTERNAL_ERROR` | Unexpected server-side error. |
+
+## Operational Diagnostics
+
+The plugin provides a node-local diagnostic CLI command:
+
+```bash
+emqx ctl sync_request status
+```
+
+Example output:
+
+```text
+Counters since plugin start:
+sync_request.requests.total: 42
+sync_request.requests.succeeded: 39
+sync_request.requests.failed: 3
+sync_request.requests.bad_request: 1
+sync_request.requests.no_subscribers: 1
+sync_request.requests.conflict: 0
+sync_request.requests.too_many_requests: 0
+sync_request.requests.dispatch_failed: 0
+sync_request.requests.timeout: 1
+sync_request.requests.internal_error: 0
+
+Current gauges:
+sync_request.inflight_requests: 0
+sync_request.pending_responses: 0
+```
+
+These values are not cluster-wide aggregates. The command reads only the node where it runs. In a cluster, run it on each node that may receive the HTTP request or deliver the MQTT response.
+
+Only requests that reach the plugin handler are counted. Management API authentication and authorization failures are handled by EMQX before the plugin runs.
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `sync_request.requests.total` | counter | HTTP sync request attempts handled. |
+| `sync_request.requests.succeeded` | counter | Requests that returned HTTP `200`. |
+| `sync_request.requests.failed` | counter | Requests that returned a non-`200` HTTP status. |
+| `sync_request.requests.bad_request` | counter | Requests rejected with `400 BAD_REQUEST`. |
+| `sync_request.requests.no_subscribers` | counter | Requests rejected because no exact, non-shared subscriber was online. |
+| `sync_request.requests.conflict` | counter | Requests rejected because the request topic matched multiple or shared subscribers. |
+| `sync_request.requests.too_many_requests` | counter | Requests rejected because `max_inflight_requests` was reached. |
+| `sync_request.requests.dispatch_failed` | counter | Requests that could not be dispatched to the subscriber node. |
+| `sync_request.requests.timeout` | counter | Requests that timed out waiting for a matching MQTT response. |
+| `sync_request.requests.internal_error` | counter | Requests that failed with an unexpected internal error. |
+| `sync_request.inflight_requests` | gauge | HTTP requests currently waiting for MQTT responses. |
+| `sync_request.pending_responses` | gauge | Pending response registrations created after request delivery. |

--- a/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
+++ b/ja_JP/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
@@ -10,7 +10,7 @@ Before using the API, install and start `emqx_sync_request` as described in [Man
 
 The request and response flow works as follows:
 
-1. The HTTP caller sends the MQTT request topic, response topic, `request_id`, and payload to the API.
+1. The HTTP caller sends an HTTP request to the API that includes the MQTT request topic, response topic, `request_id`, and payload.
 2. The plugin finds the MQTT client subscribed to the request topic and delivers the request directly to that client.
 3. The MQTT client processes the request and publishes a response to the response topic. For MQTT 5, the plugin includes `request_id` as Correlation Data in the request message.
 4. If the MQTT 5 client returns this Correlation Data, the plugin matches the response by response topic and Correlation Data. If the response does not include Correlation Data, the plugin matches it to the oldest pending request for the response topic. This fallback applies to MQTT 3 responses and MQTT 5 responses that omit Correlation Data. When concurrent requests use the same response topic, MQTT 5 clients should return the Correlation Data to ensure that each response is matched to the intended request.

--- a/zh_CN/guides/extensions/plugin-catalog.md
+++ b/zh_CN/guides/extensions/plugin-catalog.md
@@ -8,6 +8,12 @@
 
 本页面列出的插件均维护在 [`emqx.git` monorepo](https://github.com/emqx/emqx/tree/master/plugins) 中。
 
+## 消息传输
+
+[同步请求](./plugin-catalog/6.0/emqx-sync-request.md)
+
+该插件允许 HTTP 调用方通过 EMQX REST API 发布一条 MQTT 请求，并同步等待第一条匹配的 MQTT 响应。
+
 ## 运维
 
 [热升级（Relup）](./plugin-catalog/6.0/emqx-relup.md)

--- a/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
+++ b/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
@@ -1,0 +1,195 @@
+# 同步请求
+
+`emqx_sync_request` 插件允许 HTTP 服务通过 EMQX REST API 发送一条 MQTT 请求，并在同一个 HTTP 请求中获取第一条匹配的 MQTT 响应。该插件自 EMQX 企业版 6.0.4 及后续 6.0 版本可用。
+
+当后端服务需要向已连接的 MQTT 客户端发送命令或查询时，可以使用该插件。与普通消息发布 API 不同，该插件会等待并关联客户端响应、处理超时并管理并发请求。HTTP 服务无需运行 MQTT 客户端，也无需自行跟踪请求和响应的对应关系。
+
+使用 API 前，请参照[插件管理](../../plugin-management.md)安装并启动 `emqx_sync_request`。该端点仅在插件运行期间可用。
+
+## 工作原理
+
+请求和响应流程如下：
+
+1. HTTP 调用方向 API 发送 MQTT 请求主题、响应主题、`request_id` 和 Payload。
+2. 插件找到订阅请求主题的 MQTT 客户端，并将请求直接投递给该客户端。
+3. MQTT 客户端处理请求，并向响应主题发布响应。对于 MQTT 5，插件会将 `request_id` 作为请求消息的 Correlation Data。
+4. 如果 MQTT 5 客户端返回该 Correlation Data，插件会根据响应主题和 Correlation Data 精确匹配响应。如果响应未包含 Correlation Data，插件会将其匹配到该响应主题最早进入等待状态的请求。此回退方式适用于 MQTT 3，以及未返回 Correlation Data 的 MQTT 5 客户端。当并发请求使用同一个响应主题时，MQTT 5 客户端应返回 Correlation Data，以确保每条响应与预期请求匹配。
+5. 插件将第一条匹配的 MQTT 响应返回给 HTTP 调用方。如果超时前没有收到匹配的响应，API 返回 `504 TIMEOUT`。
+
+请求主题必须精确匹配一个在线的非共享订阅者：
+
+- 通配符主题过滤器不会被匹配为请求接收方。
+- 共享订阅不会被接受为请求接收方。
+- 如果没有在线的精确订阅者，API 返回 `404 NO_SUBSCRIBERS`。
+- 如果请求主题存在共享订阅，或存在多个精确订阅者，API 返回 `409 CONFLICT`。
+
+## 请求投递与响应处理
+
+该插件仅在本地节点内存中保存正在处理的请求，不会持久化请求、订阅响应主题或修改 MQTT Payload。
+
+EMQX 将请求直接投递给选定的客户端，而不经过普通 MQTT 发布流程。因此，请求不会经过规则引擎、Schema 验证、消息转换、保留消息处理或延迟发布，也不使用通用 `/publish` API。
+
+将请求转发到其他节点和等待 MQTT 响应共用同一个 HTTP 超时时间。转发耗时会减少可用于等待响应的时间。
+
+响应必须由连接到请求投递节点的客户端发布，通常使用接收请求的同一连接。通过其他节点发布的响应不会被匹配。
+
+## 插件配置
+
+以下配置控制插件在每个节点上的超时设置和资源限制。单次请求的参数请参见[请求体](#请求体)。
+
+| 字段 | 默认值 | 描述 |
+| --- | --- | --- |
+| `default_timeout` | `10s` | 请求体未指定 `timeout` 时使用的默认 HTTP 等待超时时间。 |
+| `max_timeout` | `60s` | 单个请求允许的最大 `timeout`。 |
+| `max_inflight_requests` | `10000` | 单个节点上可同时等待响应的本地 HTTP 请求数上限。 |
+| `max_payload_size` | `64KB` | MQTT 请求 Payload 和 MQTT 响应 Payload 的最大大小。 |
+
+配置示例：
+
+```hocon
+default_timeout = "10s"
+max_timeout = "60s"
+max_inflight_requests = 10000
+max_payload_size = "64KB"
+```
+
+通过标准插件配置 API 更新插件配置：
+
+```http
+PUT /api/v5/plugins/<name-vsn>/config
+```
+
+## 同步请求 API
+
+调用以下端点发送 MQTT 请求并等待响应：
+
+```http
+POST /api/v5/plugin_api/emqx_sync_request/request
+```
+
+该 API 使用与其他 EMQX 管理 API 相同的认证方式。通过 Dashboard 登录获取的 Bearer Token 可以访问该 API。API 密钥必须通过 HTTP Basic 认证发送，并且需要具备 `publish` 权限范围。
+
+### 请求体
+
+```json
+{
+  "timeout": "5s",
+  "request": {
+    "topic": "devices/1001/request",
+    "response_topic": "devices/1001/response",
+    "request_id": "request-id-1",
+    "qos": 0,
+    "payload_encoding": "plain",
+    "payload": "{\"cmd\":\"reboot\"}",
+    "content_type": "application/json"
+  }
+}
+```
+
+| 字段 | 类型 | 是否必填 | 默认值 | 描述 |
+| --- | --- | --- | --- | --- |
+| `timeout` | duration string | 否 | `default_timeout` | 等待匹配 MQTT 响应的最长时间。该值必须大于 `0`，且不超过 `max_timeout`。示例：`100ms`、`5s`、`1m`。 |
+| `request` | object | 是 | - | MQTT 请求参数。 |
+
+`request` 对象包含以下字段：
+
+| 字段 | 类型 | 是否必填 | 默认值 | 描述 |
+| --- | --- | --- | --- | --- |
+| `topic` | string | 是 | - | MQTT 请求主题。该字段必须是主题名，而不是主题过滤器，因此不允许包含 `+` 和 `#`。该主题必须有且仅有一个在线的非共享订阅者。 |
+| `response_topic` | string | 是 | - | MQTT 响应主题。该字段也必须是不包含 `+` 或 `#` 的主题名。 |
+| `request_id` | string | 是 | - | 普通字符串，用作 MQTT 5 Correlation Data，并会在 HTTP 响应中返回。最大长度为 128 字节。 |
+| `qos` | integer | 否 | `0` | 请求消息的 MQTT QoS。允许值为 `0`、`1` 和 `2`。 |
+| `payload_encoding` | string | 否 | `plain` | 请求 Payload 编码。允许值为 `plain` 和 `base64`。 |
+| `payload` | string | 是 | - | 请求 Payload。使用 `plain` 时，该字符串的字节会作为 MQTT Payload。使用 `base64` 时，该值必须是有效的 base64，解码后的字节会作为 MQTT Payload。MQTT Payload 不得超过 `max_payload_size`。 |
+| `content_type` | string | 否 | - | 请求消息的 MQTT 5 Content Type。MQTT 3 客户端不会收到该属性。 |
+
+### 成功响应
+
+请求成功时返回 HTTP `200`。MQTT 响应 Payload 始终以 base64 形式返回。
+
+```json
+{
+  "code": "OK",
+  "message": "OK",
+  "response": {
+    "topic": "devices/1001/response",
+    "request_id": "request-id-1",
+    "payload_encoding": "base64",
+    "payload": "eyJyZXN1bHQiOiJvayJ9",
+    "content_type": "application/json"
+  }
+}
+```
+
+| 字段 | 描述 |
+| --- | --- |
+| `code` | 固定为 `OK`。 |
+| `message` | 固定为 `OK`。 |
+| `response.topic` | MQTT 响应主题。 |
+| `response.request_id` | HTTP 请求中的 `request_id`。 |
+| `response.payload_encoding` | 固定为 `base64`。 |
+| `response.payload` | base64 编码后的 MQTT 响应 Payload。 |
+| `response.content_type` | 可选字段。响应 PUBLISH 中的 MQTT 5 Content Type。如果响应方未发送该属性，包括 MQTT 3 响应方，该字段会被省略。 |
+
+### 错误响应
+
+错误响应使用与其他 EMQX 管理 API 相同的 `code` 和 `message` 结构。
+
+| HTTP 状态码 | Code | 含义 |
+| --- | --- | --- |
+| `400` | `BAD_REQUEST` | JSON 请求体无效、字段值无效、请求 Payload 过大，或 MQTT 响应 Payload 过大。 |
+| `401` | `BAD_API_KEY_OR_SECRET` | API 密钥认证失败。由 EMQX 管理 API 认证逻辑返回。 |
+| `403` | `UNAUTHORIZED_ROLE` | API 密钥无权调用该 API。由 EMQX 管理 API 授权逻辑返回。 |
+| `404` | `NO_SUBSCRIBERS` | 请求主题没有在线的精确非共享订阅者。通配符订阅者会被忽略。 |
+| `409` | `CONFLICT` | 请求主题存在共享订阅，或存在多个精确订阅者。 |
+| `429` | `TOO_MANY_REQUESTS` | 本地节点已有 `max_inflight_requests` 个 HTTP 请求正在等待响应。 |
+| `503` | `SERVICE_UNAVAILABLE` | 未能将请求调度到订阅者所在节点。 |
+| `504` | `TIMEOUT` | 等待匹配 MQTT 响应超时。 |
+| `500` | `INTERNAL_ERROR` | 非预期的服务端错误。 |
+
+## 运维诊断
+
+该插件提供节点本地诊断 CLI 命令：
+
+```bash
+emqx ctl sync_request status
+```
+
+输出示例：
+
+```text
+Counters since plugin start:
+sync_request.requests.total: 42
+sync_request.requests.succeeded: 39
+sync_request.requests.failed: 3
+sync_request.requests.bad_request: 1
+sync_request.requests.no_subscribers: 1
+sync_request.requests.conflict: 0
+sync_request.requests.too_many_requests: 0
+sync_request.requests.dispatch_failed: 0
+sync_request.requests.timeout: 1
+sync_request.requests.internal_error: 0
+
+Current gauges:
+sync_request.inflight_requests: 0
+sync_request.pending_responses: 0
+```
+
+这些值不是集群范围聚合结果。该命令只读取其运行节点上的数据。在集群中，应在可能接收 HTTP 请求或投递 MQTT 响应的每个节点上运行该命令。
+
+只有到达插件处理器的请求才会被计数。管理 API 的认证和授权失败会先由 EMQX 处理，不会进入插件。
+
+| 指标 | 类型 | 描述 |
+| --- | --- | --- |
+| `sync_request.requests.total` | counter | 已处理的 HTTP 同步请求次数。 |
+| `sync_request.requests.succeeded` | counter | 返回 HTTP `200` 的请求数。 |
+| `sync_request.requests.failed` | counter | 返回非 `200` HTTP 状态码的请求数。 |
+| `sync_request.requests.bad_request` | counter | 因 `400 BAD_REQUEST` 被拒绝的请求数。 |
+| `sync_request.requests.no_subscribers` | counter | 因没有在线的精确非共享订阅者而被拒绝的请求数。 |
+| `sync_request.requests.conflict` | counter | 因请求主题匹配多个订阅者或共享订阅者而被拒绝的请求数。 |
+| `sync_request.requests.too_many_requests` | counter | 因达到 `max_inflight_requests` 而被拒绝的请求数。 |
+| `sync_request.requests.dispatch_failed` | counter | 未能调度到订阅者所在节点的请求数。 |
+| `sync_request.requests.timeout` | counter | 等待匹配 MQTT 响应超时的请求数。 |
+| `sync_request.requests.internal_error` | counter | 因非预期内部错误失败的请求数。 |
+| `sync_request.inflight_requests` | gauge | 当前正在等待 MQTT 响应的 HTTP 请求数。 |
+| `sync_request.pending_responses` | gauge | 请求投递后创建的待响应注册数量。 |

--- a/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
+++ b/zh_CN/guides/extensions/plugin-catalog/6.0/emqx-sync-request.md
@@ -10,7 +10,7 @@
 
 请求和响应流程如下：
 
-1. HTTP 调用方向 API 发送 MQTT 请求主题、响应主题、`request_id` 和 Payload。
+1. HTTP 调用方调用该 API，并在请求中提供 MQTT 请求主题、响应主题、`request_id` 和 Payload。
 2. 插件找到订阅请求主题的 MQTT 客户端，并将请求直接投递给该客户端。
 3. MQTT 客户端处理请求，并向响应主题发布响应。对于 MQTT 5，插件会将 `request_id` 作为请求消息的 Correlation Data。
 4. 如果 MQTT 5 客户端返回该 Correlation Data，插件会根据响应主题和 Correlation Data 精确匹配响应。如果响应未包含 Correlation Data，插件会将其匹配到该响应主题最早进入等待状态的请求。此回退方式适用于 MQTT 3，以及未返回 Correlation Data 的 MQTT 5 客户端。当并发请求使用同一个响应主题时，MQTT 5 客户端应返回 Correlation Data，以确保每条响应与预期请求匹配。


### PR DESCRIPTION
## Summary

- add the Sync Request plugin guide for EMQX Enterprise 6.0.4 and later 6.0 releases
- add the plugin to the English and Chinese catalogs and site navigation
- add the Japanese placeholder page

Implementation: https://github.com/emqx/emqx/pull/18012

## Validation

- checked Markdown structure and links
- parsed dir.yaml successfully
- verified the staged diff with git diff --check